### PR TITLE
Fix: No such key “sort-directories-first” in schema “org.gnome.nautil…

### DIFF
--- a/files/gschema-overrides/zz0-ublue-modifications.gschema.override
+++ b/files/gschema-overrides/zz0-ublue-modifications.gschema.override
@@ -37,6 +37,11 @@ picture-uri='file:///usr/share/backgrounds/f42/default/f42/f42-01-night.jxl'
 [org.gnome.nautilus.preferences]
 default-folder-viewer='list-view'
 show-hidden-files=true
+
+[org.gtk.settings.FileChooser]
+sort-directories-first=true
+
+[org.gtk.gtk4.settings.FileChooser]
 sort-directories-first=true
 
 [org.gnome.system.locale]


### PR DESCRIPTION
…us.preferences”

Set the `sort-directories-first` for:
- The file explorer: org.gtk.gtk4.Settings.FileChooser
- The open file dialog: org.gtk.Settings.FileChooser